### PR TITLE
fix: 修复 playids 遇数据库锁占用时执行失败

### DIFF
--- a/internal/ncmm/playids.go
+++ b/internal/ncmm/playids.go
@@ -347,6 +347,36 @@ func (c *PlayIds) RunForCookie(ctx context.Context, cookieFile string) error {
 	return nil
 }
 
+// openPlayIdsDatabase 初始化播放任务的本地进度缓存
+// 参数：无
+// 返回：数据库实例、是否启用缓存、初始化异常
+func (c *PlayIds) openPlayIdsDatabase() (database.Database, bool, error) {
+	db, err := database.NewWithOptions(c.root.Cfg.Database, 1, 0, true)
+	if err == nil {
+		return db, true, nil
+	}
+
+	if isDatabaseLockError(err) {
+		c.log("⚠️ 本地数据库已被其他进程占用，已自动降级为无缓存模式直接执行")
+		return nil, false, nil
+	}
+
+	return nil, false, fmt.Errorf("本地数据库初始化失败: %w", err)
+}
+
+// isDatabaseLockError 判断数据库初始化失败是否由目录锁占用触发
+// 参数：err 表示数据库初始化返回的异常
+// 返回：true 表示当前异常可降级为无缓存模式
+func isDatabaseLockError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errMsg := strings.ToLower(err.Error())
+	return strings.Contains(errMsg, "lock") ||
+		strings.Contains(errMsg, "resource temporarily unavailable") ||
+		strings.Contains(errMsg, "process cannot access") ||
+		strings.Contains(errMsg, "temporarily unavailable")
+}
 
 func (c *PlayIds) executeForCookie(ctx context.Context, cookieFile string, uniqueIds []string) (int64, error) {
 	// 1. 网络客户端与登录校验
@@ -378,12 +408,14 @@ func (c *PlayIds) executeForCookie(ctx context.Context, cookieFile string, uniqu
 	var uid = fmt.Sprintf("%v", user.Account.Id)
 	c.log("当前账号：uid=%s 昵称=\"%s\"", uid, user.Profile.Nickname)
 
-	// 2. 初始化本地 Badger 数据库
-	db, err := database.New(c.root.Cfg.Database)
+	// 2. 初始化本地进度缓存。播放任务遇到 Badger 目录锁时只失去跨进程进度记忆，不能中断本次播放链路。
+	db, cacheEnabled, err := c.openPlayIdsDatabase()
 	if err != nil {
-		return 0, fmt.Errorf("本地数据库初始化失败: %w", err)
+		return 0, err
 	}
-	defer db.Close(ctx)
+	if db != nil {
+		defer db.Close(ctx)
+	}
 
 	syncSessionConfig(ctx, cli, cookieFile, user.Account.Id, db, nil)
 
@@ -394,48 +426,53 @@ func (c *PlayIds) executeForCookie(ctx context.Context, cookieFile string, uniqu
 
 	// 3. 确定今日目标播放上限 (根据 daily_min 和 daily_max 生成)
 	var dailyTarget int64
-	targetRecord, err := db.Get(ctx, playIdsDailyTargetKey(uid))
-	if err != nil {
-		if strings.Contains(err.Error(), "Key not found") {
-			// 未设置，随机生成今日目标
-			dailyMin := c.opts.DailyMin
-			if dailyMin == 0 && c.root.Cfg.PlayIds != nil {
-				dailyMin = c.root.Cfg.PlayIds.DailyMin
-			}
-			if dailyMin == 0 {
-				dailyMin = 50
-			}
+	if cacheEnabled {
+		targetRecord, err := db.Get(ctx, playIdsDailyTargetKey(uid))
+		if err == nil {
+			dailyTarget, _ = strconv.ParseInt(string(targetRecord), 10, 64)
+		} else if !strings.Contains(err.Error(), "Key not found") {
+			return 0, fmt.Errorf("读取今日播放目标失败: %w", err)
+		}
+	}
+	if dailyTarget == 0 {
+		// 本日第一次播放或无缓存执行时，按配置随机生成今日播放上限
+		dailyMin := c.opts.DailyMin
+		if dailyMin == 0 && c.root.Cfg.PlayIds != nil {
+			dailyMin = c.root.Cfg.PlayIds.DailyMin
+		}
+		if dailyMin == 0 {
+			dailyMin = 50
+		}
 
-			dailyMax := c.opts.DailyMax
-			if dailyMax == 0 && c.root.Cfg.PlayIds != nil {
-				dailyMax = c.root.Cfg.PlayIds.DailyMax
-			}
-			if dailyMax == 0 {
-				dailyMax = 200
-			}
+		dailyMax := c.opts.DailyMax
+		if dailyMax == 0 && c.root.Cfg.PlayIds != nil {
+			dailyMax = c.root.Cfg.PlayIds.DailyMax
+		}
+		if dailyMax == 0 {
+			dailyMax = 200
+		}
 
-			r := rand.New(rand.NewSource(time.Now().UnixNano()))
-			if dailyMax > dailyMin {
-				dailyTarget = dailyMin + r.Int63n(dailyMax-dailyMin+1)
-			} else {
-				dailyTarget = dailyMin
-			}
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		if dailyMax > dailyMin {
+			dailyTarget = dailyMin + r.Int63n(dailyMax-dailyMin+1)
+		} else {
+			dailyTarget = dailyMin
+		}
+		if cacheEnabled {
 			err = db.Set(ctx, playIdsDailyTargetKey(uid), strconv.FormatInt(dailyTarget, 10), expire)
 			if err != nil {
 				c.log("[WARN] 写入今日随机目标失败: %s", err)
 			}
-		} else {
-			return 0, fmt.Errorf("读取今日播放目标失败: %w", err)
 		}
-	} else {
-		dailyTarget, _ = strconv.ParseInt(string(targetRecord), 10, 64)
 	}
 
 	// 4. 读取今日已播数量
 	var dailyCompleted int64 = 0
-	completedRecord, err := db.Get(ctx, playIdsTodayNumKey(uid))
-	if err == nil {
-		dailyCompleted, _ = strconv.ParseInt(string(completedRecord), 10, 64)
+	if cacheEnabled {
+		completedRecord, err := db.Get(ctx, playIdsTodayNumKey(uid))
+		if err == nil {
+			dailyCompleted, _ = strconv.ParseInt(string(completedRecord), 10, 64)
+		}
 	}
 
 	c.log("今日风控目标: 已完成=%d首, 今日随机上限=%d首", dailyCompleted, dailyTarget)
@@ -670,11 +707,13 @@ func (c *PlayIds) executeForCookie(ctx context.Context, cookieFile string, uniqu
 		// C. 内层小循环：顺序播放当前轮次的每首歌曲
 		var isInterrupted = false
 		for roundIdx, songId := range validRoundList {
-			// 校验当前是否达到了今日最大上限
-			var currentCompleted int64 = 0
-			currentRecord, err := db.Get(ctx, playIdsTodayNumKey(uid))
-			if err == nil {
-				currentCompleted, _ = strconv.ParseInt(string(currentRecord), 10, 64)
+			// 校验当前是否达到了今日最大上限；无缓存模式只能使用本进程内已经完成的播放数
+			currentCompleted := dailyCompleted + totalPlayedCount
+			if cacheEnabled {
+				currentRecord, err := db.Get(ctx, playIdsTodayNumKey(uid))
+				if err == nil {
+					currentCompleted, _ = strconv.ParseInt(string(currentRecord), 10, 64)
+				}
 			}
 			if currentCompleted >= dailyTarget {
 				c.log("  [playids] ⚠️ 触发今日风控随机播放总上限 (%d首)，优雅退出当前运行", dailyTarget)
@@ -815,12 +854,14 @@ func (c *PlayIds) executeForCookie(ctx context.Context, cookieFile string, uniqu
 			}
 
 			// 记录数据库日志
-			if err := db.Set(ctx, playIdsRecordKey(uid, songId), fmt.Sprintf("%v", time.Now().UnixMilli())); err != nil {
-				c.log("[WARN] 保存歌曲播放记录 %s 至本地数据库失败: %s", songId, err)
+			if cacheEnabled {
+				if err := db.Set(ctx, playIdsRecordKey(uid, songId), fmt.Sprintf("%v", time.Now().UnixMilli())); err != nil {
+					c.log("[WARN] 保存歌曲播放记录 %s 至本地数据库失败: %s", songId, err)
+				}
 			}
 
 			// 只有计入目标的歌曲，才去自增今日已完成计数
-			if shouldCount {
+			if cacheEnabled && shouldCount {
 				_, err = db.Increment(ctx, playIdsTodayNumKey(uid), 1, expire)
 				if err != nil {
 					c.log("[WARN] 自增今日已完成次数失败: %s", err)

--- a/internal/ncmm/playids_test.go
+++ b/internal/ncmm/playids_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 xxx. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
+
+package ncmm
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestIsDatabaseLockErrorMatched 验证数据库目录锁占用时会进入无缓存播放分支
+// 参数：t 表示测试上下文
+// 返回：无
+func TestIsDatabaseLockErrorMatched(t *testing.T) {
+	cases := []error{
+		errors.New(`failed to open badger db: Cannot acquire directory lock on "./database/badger/". Another process is using this Badger database. err: resource temporarily unavailable`),
+		errors.New("open LOCK: process cannot access the file because it is being used by another process"),
+	}
+
+	for _, err := range cases {
+		// 1. 数据库目录锁被其他运行实例占用时，播放任务可以降级为无缓存模式
+		if !isDatabaseLockError(err) {
+			t.Fatalf("expected lock error to be matched: %v", err)
+		}
+	}
+}
+
+// TestIsDatabaseLockErrorIgnoresConfigErrors 验证非锁类数据库异常仍然暴露给调用方
+// 参数：t 表示测试上下文
+// 返回：无
+func TestIsDatabaseLockErrorIgnoresConfigErrors(t *testing.T) {
+	cases := []error{
+		nil,
+		errors.New("unsupported database driver: sqlite"),
+		errors.New("permission denied"),
+	}
+
+	for _, err := range cases {
+		// 1. 配置错误和权限错误不是可安全降级的缓存锁冲突
+		if isDatabaseLockError(err) {
+			t.Fatalf("expected non-lock error to be ignored: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
playids 初始化本地 Badger 缓存时，如果数据库目录已被其他进程占用，
降级为无缓存模式继续执行播放任务，避免批量任务被锁冲突中断。

无缓存模式下使用本进程内的播放计数控制本次运行；数据库可用时，
仍保持原有的每日目标、播放记录和进度缓存逻辑。

补充数据库锁错误识别的单元测试，确保配置错误不会被误判为可降级的锁冲突。