### PR TITLE
Updated entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,23 +1,33 @@
-#!/bin/sh
+#!/bin/sh -e
 
-set -e
+# ===== 防cron自举死循环（保留之前的修复）=====
+if [ -n "$1" ] && [ "$1" != "cron" ]; then
+  exec ncmm -c /data/config.yaml "$@"
+fi
 
-# 1. 首次启动检测并释放配置文件到挂载目录
+# 1. 首次启动释放配置文件
 if [ ! -f /data/config.yaml ]; then
   echo "Initializing default config.yaml..."
   mkdir -p /data
   cp /etc/ncmm/config.yaml /data/config.yaml
 fi
 
-# 2. 解析环境变量中的多重定时任务
-# 清空已有的 crontab，防止重复追加
-true > /etc/crontabs/root
+# ===== 【核心修改点1】先把CookieCloud同步挪到最前面，不管有没有定时任务都先同步 =====
+if [ "$COOKIECLOUD_UUID" != "your-uuid" ] && [ -n "$COOKIECLOUD_UUID" ]; then
+  echo "Syncing cookies from CookieCloud..."
+  # 同步失败也不退出，避免定时任务完全无法启动，只打警告
+  ncmm -c /data/config.yaml login cookiecloud \
+    -u "$COOKIECLOUD_UUID" \
+    -p "$COOKIECLOUD_PASSWORD" \
+    -s "$COOKIECLOUD_SERVER" -m || echo "Warning: CookieCloud sync failed, will proceed with existing cookies."
+fi
 
-# 导出关键环境变量以供 cron 任务调用
+# 2. 解析环境变量中的多重定时任务
+: > /etc/crontabs/root
 mkdir -p /etc/ncmm
 printenv | grep -E '^(COOKIECLOUD_|TZ|PATH=)' | sed 's/^/export /' > /etc/ncmm/env.sh
 
-# 方案 A：从 command 块传入定时任务 ($1 = "cron" 模式)
+# 方案A：从command块传入定时任务
 if [ "$1" = "cron" ]; then
   echo "Cron mode detected (via command arguments). Parsing schedules..."
   echo "$2" | while read -r line; do
@@ -33,17 +43,15 @@ EOF
   done
 fi
 
-# 方案 B：从以 CRON 开头的环境变量中解析定时任务
+# 方案B：从CRON_xxx环境变量解析定时任务
 env | grep -E '^CRON' | while read -r env_var; do
   value=$(echo "$env_var" | cut -d'=' -f2-)
   [ -z "$value" ] && continue
-
   read -r m h dom mon dow cmd <<EOF
 $value
 EOF
   if [ -n "$m" ] && [ -n "$h" ] && [ -n "$dom" ] && [ -n "$mon" ] && [ -n "$dow" ] && [ -n "$cmd" ]; then
     cron_expr="$m $h $dom $mon $dow"
-    # 避免和 Command 里的规则重复
     if ! grep -qF "$cron_expr . /etc/ncmm/env.sh && /entrypoint.sh $cmd" /etc/crontabs/root; then
       echo "$cron_expr . /etc/ncmm/env.sh && /entrypoint.sh $cmd > /proc/1/fd/1 2>&1" >> /etc/crontabs/root
       echo "Added cron job (env): $cron_expr -> ncmm $cmd"
@@ -59,24 +67,18 @@ EOF
   fi
 done
 
-# 如果生成了有效的 crontab 规则，启动 crond 守护进程
+# ===== 【核心修改点2】同步完Cookie再启动crond，逻辑不变 =====
 if [ -s /etc/crontabs/root ]; then
   echo "Starting crond daemon..."
-  exec crond -f -l 2
+  chmod 600 /etc/crontabs/root
+  exec crond -f -l 8
 fi
 
-# 3. 如果未配置任何定时任务，则是单次运行模式：同步 Cookie 并执行传入命令
+# 无定时任务时的单次执行逻辑（保留）
 if [ "$1" = "cron" ]; then
   echo "Error: Cron mode requested but no valid schedules found."
   exit 1
 fi
 
-if [ "$COOKIECLOUD_UUID" != "your-uuid" ] && [ -n "$COOKIECLOUD_UUID" ]; then
-  echo "Syncing cookies from CookieCloud..."
-  ncmm -c /data/config.yaml login cookiecloud \
-    -u "$COOKIECLOUD_UUID" \
-    -p "$COOKIECLOUD_PASSWORD" \
-    -s "$COOKIECLOUD_SERVER" -m || echo "Warning: CookieCloud sync failed, will proceed with existing cookies."
-fi
-
+# 兜底执行（保留）
 exec ncmm -c /data/config.yaml "$@"


### PR DESCRIPTION
1. 防cron自举死循环 :
if [ -n "$1" ] && [ "$1" != "cron" ]; then
  exec ncmm -c /data/config.yaml "$@"
fi
2. 把【CookieCloud同步】移到最前面（解决定时任务Cookie失效）
位置：在“首次启动检测”之后，“解析定时任务”之前。
3. 删除【多余的cp命令】（解决QNAP重启报错）
位置：在 if [ -s /etc/crontabs/root ]; then代码块内部。
作用：QNAP里两个路径是同一个文件，不能复制，只能改权限。