### PR TITLE
feat: 增加任务失败推送，并在 task 调度中做会话失效短路

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 为了获得更好的阅读体验，本项目的详细使用手册已拆分为以下子文档：
 
 * ⚙️ [配置文件详解](docs/configuration.md) — 了解 `config.yaml` 详细配置字段及各项任务开关说明。
+* 🔔 [失败通知](docs/notify.md) — 运行失败汇总推送（Webhook / Bark / TG / 钉钉等，通道配置独立 `notify.yaml`）。
 * 🐳 [Docker 部署指南](docs/docker.md) — 了解如何通过 Docker/Docker Compose 一键部署并配合定时任务运行。
 * 📖 [命令行使用说明](docs/cli.md) — 查看完整的命令树、通用参数以及所有子命令的使用实例。
 * 👥 [多账号隔离最佳实践](docs/multi-accounts.md) — 学习如何使用 `--home` 管理多个粉丝账号，实现全自动接力刷量。

--- a/config/config.go
+++ b/config/config.go
@@ -187,6 +187,23 @@ type UpdaterConf struct {
 	ProxyMirrors []string `json:"proxy_mirrors" yaml:"proxy_mirrors"`
 }
 
+// NotifyConf 通知策略配置（通道凭证在独立 notify.yaml 中，见 File）。
+type NotifyConf struct {
+	Enabled     bool   `json:"enabled" yaml:"enabled"`
+	OnSkip      *bool  `json:"on_skip" yaml:"on_skip"` // 是否推送 skip，默认 true
+	TitlePrefix string `json:"title_prefix" yaml:"title_prefix"`
+	Timeout     string `json:"timeout" yaml:"timeout"` // 单通道超时，如 10s
+	File        string `json:"file" yaml:"file"`       // 通道配置文件路径，默认 notify.yaml
+}
+
+// OnSkipEnabled 返回 skip 是否需要推送（默认 true）。
+func (n *NotifyConf) OnSkipEnabled() bool {
+	if n == nil || n.OnSkip == nil {
+		return true
+	}
+	return *n.OnSkip
+}
+
 type Config struct {
 	v              *viper.Viper
 	Version        string              `json:"version" yaml:"version"`
@@ -204,6 +221,7 @@ type Config struct {
 	VipMemberGift  *VipMemberGiftConf  `json:"vipMemberGift" yaml:"vipMemberGift"`
 	Task           *TaskConf           `json:"task" yaml:"task"`
 	Updater        *UpdaterConf        `json:"updater" yaml:"updater"`
+	Notify         *NotifyConf         `json:"notify" yaml:"notify"`
 }
 
 // MusicianConf 音乐人任务配置
@@ -419,6 +437,22 @@ func (c *Config) Validate() error {
 				"ListenIndie", "PlayDailyRecommend", "playids", "musician-vip",
 			}
 		}
+	}
+	if c.Notify == nil {
+		c.Notify = &NotifyConf{}
+	}
+	if c.Notify.OnSkip == nil {
+		onSkip := true
+		c.Notify.OnSkip = &onSkip
+	}
+	if strings.TrimSpace(c.Notify.TitlePrefix) == "" {
+		c.Notify.TitlePrefix = "ncmm"
+	}
+	if strings.TrimSpace(c.Notify.Timeout) == "" {
+		c.Notify.Timeout = "10s"
+	}
+	if strings.TrimSpace(c.Notify.File) == "" {
+		c.Notify.File = "notify.yaml"
 	}
 	return nil
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,5 @@
 # 配置文件版本
-version: 1.1.9
+version: 1.1.11
 
 # 顶级多账号管理
 accounts:
@@ -8,7 +8,7 @@ accounts:
   # 辅助账号 Cookie 列表
   secondary:
     - "./fan1.json"
-    - "./fan2.json"
+    - "./fan2.json" # 不要的账号可以删除或者前面加#注释
   # 每个 Cookie 对应的移动端 X-antiCheatToken（从各自的移动端抓包获取，每个设备/账号唯一）
   # 目前需要 antiCheatToken 的任务有：dailySongShare 和 vipMemberGift(领取)。
   # 同时需要移动端 Cookie 和匹配的移动端 UA。没有配置 token 的账号会自动跳过需要该 token 的任务。
@@ -17,31 +17,56 @@ accounts:
     "./cookie.json": ""
     # "./fan1.json": ""
 
+# ncmm task 批量任务执行配置总开关。
+# 若命令行没有指定任何具体任务(例如运行 ncmm task)，则会执行 task 中所有配置为 true 的任务。
+# 若命令行指定了任意具体任务(例如运行 ncmm task --sign --playids)，则仅会执行这些被命令行明确开启的任务，而忽略其他未指定的任务。
+task:
+  # 是否在批量执行中包含日常一键签到
+  sign: true
+  # 是否在批量执行中包含播放指定歌曲任务
+  playids: true
+  # 是否在批量执行中包含音乐人日常签到任务（每日）
+  musician-sign: true
+  # 是否在批量执行中包含音乐人VIP进阶任务（每月）
+  musician-vip: false
+  # 是否在批量执行中包含自动发布/删除图文笔记任务
+  note: false
+  # 是否开启每日分享歌曲并抽奖，需要填写antiCheatTokens
+  daily-song-share: true
+  # 是否开启赠送和领取VIP任务，需要填写antiCheatTokens
+  vip-member-gift: true
+  # 是否在批量执行中包含乐迷团任务
+  fansgroup: true
 
-# log 日志模块配置
-log:
-  # 应用名称
-  app: ncm
-  # 日志输出格式: text / json
-  format: text
-  # 日志级别: debug < info < warn < error
-  level: info
-  # 日志是否输出到标准输出 (控制台)
-  stdout: false
-  # 滚动日志配置
-  rotate:
-    # 日志文件保存路径
-    filename: "./log/ncm.log"
-    # 单个日志文件最大大小 (单位: MB)
-    maxsize: 100
-    # 日志文件保留天数
-    maxage: 7
-    # 日志文件保留最大数量
-    maxbackups: 3
-    # 日志打印是否使用本地时间
-    localtime: true
-    # 日志文件是否启用 gzip 压缩
-    compress: true
+  # 任务调度与队列配置
+  # 执行模式:
+  #   - "by-task-group": 跨账号分群组串行。所有账号跑完快任务，再开始跑慢任务。
+  #   - "by-account": 单账号自包容串行。每个账号执行完快任务和慢任务后，再轮到下一个账号。
+  mode: "by-task-group"
+
+  # 快任务列表。包含所有耗时秒级的常规打卡任务。正常不需要修改
+  fast_tasks:
+    - daily-song-share     # 每日推歌发布任务
+    - VipTask              # 黑胶 VIP 任务
+    - Reserve              # 预约领云贝
+    - ViewVipCenter        # 浏览会员中心
+    - LikeComment          # 点赞评论和动态
+    - FollowArtist         # 关注歌手
+    - LikeSong             # 红心歌曲
+    - CollectSong          # 收藏歌曲
+    - PublishNote          # 发布图文动态
+    - musician-sign        # 音乐人日常签到
+    - note                 # 自动发布/删除图文笔记任务
+    - vip-member-gift      # 黑胶会员赠送和领取任务（云端）
+    - fansgroup            # 乐迷团任务
+
+  # 慢任务列表。包含所有听歌、刷播放量等耗时数分钟到数十分钟的任务。
+  slow_tasks:
+    - ListenIndie          # 探索小众歌曲 (约7分钟)
+    - PlayDailyRecommend   # 日推歌曲播放 (约30~45分钟)
+    - playids              # 播放指定歌曲任务
+    - musician-vip         # 音乐人VIP进阶任务 (含播放任务)
+
 
 # 网络模块配置
 network:
@@ -62,12 +87,7 @@ network:
     # XEAPI/AEAPI Android 移动客户端 User-Agent。Android 每日推歌、Android vipMemberGift 需要填写抓包移动端 UA。
     xeapi: ""
 
-# 数据缓存配置 (主要记录播放状态进度)
-database:
-  # 缓存驱动，目前仅支持 badger
-  driver: badger
-  # 缓存目录路径
-  path: "./database/badger/"
+
 
 # playids 播放指定歌曲配置
 playids:
@@ -91,7 +111,7 @@ playids:
   # 示例 (多源配置):
   idsFile:
     - "https://mum.cc.cd/34p793j2"
-    # - "local/ids.txt"
+    # - "./ids.txt"
   # 播放账号控制（命令行参数未指定 --cookie-file 时生效）
 
 # 签到任务配置
@@ -260,55 +280,7 @@ fansgroup:
   # 乐迷团发布笔记后是否自动删除（留空则继承 note.autoDelete 配置）
   # autoDeleteNote: true
 
-# 批量任务执行配置
-# 若命令行没有指定任何具体任务(例如运行 ncmm task)，则会执行 task 中所有配置为 true 的任务。
-# 若命令行指定了任意具体任务(例如运行 ncmm task --sign --playids)，则仅会执行这些被命令行明确开启的任务，而忽略其他未指定的任务。
-task:
-  # 是否在批量执行中包含日常一键签到
-  sign: true
-  # 是否在批量执行中包含播放指定歌曲任务
-  playids: true
-  # 是否在批量执行中包含音乐人日常签到任务（每日）
-  musician-sign: true
-  # 是否在批量执行中包含音乐人VIP进阶任务（每月）
-  musician-vip: false
-  # 是否在批量执行中包含自动发布/删除图文笔记任务
-  note: false
-  # 是否开启每日分享歌曲并抽奖，需要填写antiCheatTokens
-  daily-song-share: true
-  # 是否开启赠送和领取VIP任务，需要填写antiCheatTokens
-  vip-member-gift: true
-  # 是否在批量执行中包含乐迷团任务
-  fansgroup: true
 
-  # 任务调度与队列配置
-  # 执行模式:
-  #   - "by-task-group": 跨账号分群组串行。所有账号跑完快任务，再开始跑慢任务。
-  #   - "by-account": 单账号自包容串行。每个账号执行完快任务和慢任务后，再轮到下一个账号。
-  mode: "by-task-group"
-
-  # 快任务列表。包含所有耗时秒级的常规打卡任务。
-  fast_tasks:
-    - daily-song-share     # 每日推歌发布任务
-    - VipTask              # 黑胶 VIP 任务
-    - Reserve              # 预约领云贝
-    - ViewVipCenter        # 浏览会员中心
-    - LikeComment          # 点赞评论和动态
-    - FollowArtist         # 关注歌手
-    - LikeSong             # 红心歌曲
-    - CollectSong          # 收藏歌曲
-    - PublishNote          # 发布图文动态
-    - musician-sign        # 音乐人日常签到
-    - note                 # 自动发布/删除图文笔记任务
-    - vip-member-gift      # 黑胶会员赠送和领取任务（云端）
-    - fansgroup            # 乐迷团任务
-
-  # 慢任务列表。包含所有听歌、刷播放量等耗时数分钟到数十分钟的任务。
-  slow_tasks:
-    - ListenIndie          # 探索小众歌曲 (约7分钟)
-    - PlayDailyRecommend   # 日推歌曲播放 (约30~45分钟)
-    - playids              # 播放指定歌曲任务
-    - musician-vip         # 音乐人VIP进阶任务 (含播放任务)
 
 # 自动更新与版本检测配置
 updater:
@@ -322,3 +294,50 @@ updater:
     - "https://gh-proxy.com/"
     - "https://ghproxy.net/"
     - "https://githubproxy.cc/"
+
+# 运行失败通知（策略在此；通道凭证见独立文件 notify.yaml）
+# 仅在有失败或（on_skip=true 时的）跳过时，于进程结束汇总推送一条消息；成功不推送。
+notify:
+  # 总开关，默认关闭
+  enabled: false
+  # 任务被跳过（如缺 antiCheatToken）时是否纳入汇总推送，默认关闭
+  on_skip: false
+  # 推送标题前缀，便于多机区分
+  title_prefix: "ncmm"
+  # 单通道请求超时
+  timeout: 10s
+  # 通道配置文件路径（相对路径相对于 config.yaml 所在目录；无自定义 config 时相对 --home）
+  file: "notify.yaml"
+
+# log 日志模块配置
+log:
+  # 应用名称
+  app: ncm
+  # 日志输出格式: text / json
+  format: text
+  # 日志级别: debug < info < warn < error
+  level: info
+  # 日志是否输出到标准输出 (控制台)
+  stdout: false
+  # 滚动日志配置
+  rotate:
+    # 日志文件保存路径
+    filename: "./log/ncm.log"
+    # 单个日志文件最大大小 (单位: MB)
+    maxsize: 100
+    # 日志文件保留天数
+    maxage: 7
+    # 日志文件保留最大数量
+    maxbackups: 3
+    # 日志打印是否使用本地时间
+    localtime: true
+    # 日志文件是否启用 gzip 压缩
+    compress: true
+
+
+# 数据缓存配置 (主要记录播放状态进度)
+database:
+  # 缓存驱动，目前仅支持 badger
+  driver: badger
+  # 缓存目录路径
+  path: "./database/badger/"

--- a/config/notify.yaml
+++ b/config/notify.yaml
@@ -1,0 +1,64 @@
+# ncmm 通知通道配置示例
+# 复制为 notify.yaml（或与 config.notify.file 指定路径一致）后填写凭证。
+# 策略开关在 config.yaml 的 notify 节点；本文件只放通道。
+
+# 自定义 Webhook（POST JSON，可用 body_template 适配飞书/Discord 等）
+webhook:
+  enabled: false
+  url: ""
+  method: POST
+  headers: {}
+  # 留空使用默认: {"title","content","level","time","host"}
+  # body_template: |
+  #   {"msg_type":"text","content":{"text":"{{title}}\n{{content}}"}}
+  body_template: ""
+
+# Bark
+bark:
+  enabled: false
+  key: ""
+  server: ""   # 自建地址，空则 https://api.day.app
+
+# Server酱 / Server酱 Turbo（SCT 开头 key 走 sctapi）
+serverchan:
+  enabled: false
+  sckey: ""
+
+# Telegram
+telegram:
+  enabled: false
+  bot_token: ""
+  user_id: ""
+  api_host: ""   # 可选反代，如 http://tg-api.example.com
+  proxy: ""      # 可选 http 代理，如 http://127.0.0.1:7890
+
+# 钉钉机器人（加签 secret 可选）
+dingtalk:
+  enabled: false
+  access_token: ""
+  secret: ""
+
+# QQ CoolPush / Qmsg
+coolpush:
+  enabled: false
+  skey: ""
+  mode: "send"   # send / group 等
+
+# PushPlus
+pushplus:
+  enabled: false
+  token: ""
+
+# 企业微信群机器人
+wecom_key:
+  enabled: false
+  key: ""
+
+# 企业微信应用消息
+wecom_app:
+  enabled: false
+  corp_id: ""
+  corp_secret: ""
+  to_user: "@all"
+  agent_id: ""
+  media_id: ""   # 可选，填写则发 mpnews

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -249,3 +249,18 @@ musician:
     # 两首歌曲之间的最大随机等待间隔（秒，为 0 则继承 playids.gap_max）
     gap_max: 0
 ```
+
+## 失败通知
+
+运行失败汇总推送说明见 [notify.md](notify.md)。
+
+`config.yaml` 中仅配置策略（通道凭证放独立文件 `notify.yaml`，示例见仓库 `config/notify.yaml`）：
+
+```yaml
+notify:
+  enabled: false      # 总开关，默认关闭
+  on_skip: false       # 跳过是否纳入汇总推送，默认 false
+  title_prefix: "ncmm"
+  timeout: 10s
+  file: "notify.yaml" # 相对路径相对于 config.yaml 所在目录
+```

--- a/docs/notify.md
+++ b/docs/notify.md
@@ -1,0 +1,65 @@
+# 失败通知
+
+运行失败时（未登录、任务报错、可选的 skip）在进程结束时汇总推送 **一条** 消息。成功不推送。
+
+## 配置拆分
+
+| 文件 | 内容 |
+|------|------|
+| `config.yaml` → `notify` | 策略：开关、是否推 skip、标题前缀、超时、通道文件路径 |
+| `notify.yaml` | 通道凭证（Webhook / Bark / TG / 钉钉等） |
+
+示例通道文件见仓库`config`目录的 `notify.yaml`，复制为 `notify.yaml` 后填写。
+
+### config.yaml
+
+```yaml
+notify:
+  enabled: false       # 总开关，如需开启改为：true
+  on_skip: false       # skip 是否纳入汇总，默认 false
+  title_prefix: "ncmm" # 推送标题前缀，便于多机区分
+  timeout: 10s
+  file: "notify.yaml" # 相对路径：相对 config.yaml 所在目录
+```
+
+### 启用步骤
+
+1. `config.yaml` 设置 `notify.enabled: true`
+2. 复制 `notify.yaml`（与 config.yaml 同目录或 `notify.file` 指定路径），配置对应推送通道需要的参数
+3. 打开需要的通道并填写凭证
+
+## 支持通道
+
+- 自定义 Webhook（`body_template` 支持 `{{title}}` `{{content}}` `{{level}}` `{{time}}` `{{host}}`）
+- Bark
+- Server酱 / Server酱 Turbo
+- Telegram
+- 钉钉机器人
+- QQ CoolPush (Qmsg)
+- PushPlus
+- 企业微信群机器人
+- 企业微信应用
+
+## 环境变量（可选，覆盖/补齐密钥）
+
+| 变量 | 说明 |
+|------|------|
+| `NCMM_NOTIFY_WEBHOOK_URL` | Webhook URL |
+| `NCMM_BARK_KEY` | Bark key |
+| `NCMM_BARK_SERVER` | Bark 自建地址 |
+| `NCMM_SCKEY` | Server酱 |
+| `NCMM_TG_BOT_TOKEN` / `NCMM_TG_USER_ID` | Telegram |
+| `NCMM_TG_API_HOST` / `NCMM_TG_PROXY` | Telegram 反代/代理 |
+| `NCMM_DD_BOT_ACCESS_TOKEN` / `NCMM_DD_BOT_SECRET` | 钉钉 |
+| `NCMM_QQ_SKEY` / `NCMM_QQ_MODE` | CoolPush |
+| `NCMM_PUSH_PLUS_TOKEN` | PushPlus |
+| `NCMM_QYWX_KEY` | 企微群机器人 |
+| `NCMM_QYWX_AM` | 企微应用：`corpid,secret,touser,agentid[,media_id]` |
+
+设置对应 env 时会自动启用该通道（无需 yaml 中 enabled）。
+
+## 行为说明
+
+- `ncmm task` 与独立命令（`sign` / `playids` / …）均会收集，并在进程结束时汇总推送
+- 通知发送失败只写日志，不影响任务结果与退出码
+- 无失败且（`on_skip=false` 或无 skip）时不推送

--- a/internal/ncmm/daily_song_share.go
+++ b/internal/ncmm/daily_song_share.go
@@ -92,10 +92,12 @@ func (c *DailySongShare) getConfig() (*config.DailySongShareConf, error) {
 func (c *DailySongShare) execute(ctx context.Context) error {
 	cfg, err := c.getConfig()
 	if err != nil {
+		c.root.ReportFailure("-", "daily-song-share", err)
 		return err
 	}
 	if err := c.validatePrerequisites(cfg); err != nil {
 		c.cmd.Printf("[daily-song-share] skipped: %v\n", err)
+		c.root.ReportSkip("-", "daily-song-share", err.Error())
 		return nil
 	}
 
@@ -104,7 +106,9 @@ func (c *DailySongShare) execute(ctx context.Context) error {
 		queue = append(queue, c.opts.CookieFile)
 	} else {
 		if c.root.Cfg.Accounts == nil {
-			return fmt.Errorf("missing accounts section")
+			err := fmt.Errorf("missing accounts section")
+			c.root.ReportFailure("-", "daily-song-share", err)
+			return err
 		}
 		if cfg.EnableMain && c.root.Cfg.Accounts.Main != "" {
 			queue = append(queue, c.root.Cfg.Accounts.Main)
@@ -120,6 +124,7 @@ func (c *DailySongShare) execute(ctx context.Context) error {
 
 	if len(queue) == 0 {
 		c.cmd.Println("[daily-song-share] no available accounts, please check config.yaml")
+		c.root.ReportSkip("-", "daily-song-share", "no available accounts")
 		return nil
 	}
 
@@ -127,6 +132,11 @@ func (c *DailySongShare) execute(ctx context.Context) error {
 		c.cmd.Printf("[daily-song-share] start account (%s)\n", cookieFile)
 		if _, err := c.ExecuteForCookie(ctx, cookieFile); err != nil {
 			c.cmd.Printf("[daily-song-share] account failed (%s): %v\n", cookieFile, err)
+			if strings.Contains(err.Error(), "跳过") || strings.Contains(strings.ToLower(err.Error()), "skip") {
+				c.root.ReportSkip(cookieFile, "daily-song-share", err.Error())
+			} else {
+				c.root.ReportFailure(cookieFile, "daily-song-share", err)
+			}
 		}
 		c.cmd.Println("[daily-song-share] --------------------------------------------------")
 		if i < len(queue)-1 {

--- a/internal/ncmm/fansgroup.go
+++ b/internal/ncmm/fansgroup.go
@@ -84,7 +84,9 @@ func (c *FansGroup) execute(ctx context.Context) error {
 	} else {
 		cfg := c.root.Cfg
 		if cfg.Accounts == nil {
-			return fmt.Errorf("missing accounts section")
+			err := fmt.Errorf("missing accounts section")
+			c.root.ReportFailure("-", "fansgroup", err)
+			return err
 		}
 		if cfg.FansGroup != nil && cfg.FansGroup.EnableMain && cfg.Accounts.Main != "" {
 			queue = append(queue, cfg.Accounts.Main)
@@ -96,6 +98,7 @@ func (c *FansGroup) execute(ctx context.Context) error {
 
 	if len(queue) == 0 {
 		c.cmd.Println("[fansgroup] 未配置可用账号，请检查 config.yaml")
+		c.root.ReportSkip("-", "fansgroup", "未配置可用账号")
 		return nil
 	}
 
@@ -103,6 +106,7 @@ func (c *FansGroup) execute(ctx context.Context) error {
 		c.cmd.Printf("[fansgroup] 开始处理账号 (%s)\n", cookie)
 		if err := c.ExecuteForCookie(ctx, cookie); err != nil {
 			c.cmd.Printf("[fansgroup] 账号处理失败 (%s): %v\n", cookie, err)
+			c.root.ReportFailure(cookie, "fansgroup", err)
 		}
 		c.cmd.Println("[fansgroup] --------------------------------------------------")
 

--- a/internal/ncmm/musician.go
+++ b/internal/ncmm/musician.go
@@ -264,12 +264,16 @@ func (mc *musicianContext) close(ctx context.Context) {
 
 func (c *Musician) execute(ctx context.Context) error {
 	if err := c.validate(); err != nil {
-		return fmt.Errorf("validate: %w", err)
+		err = fmt.Errorf("validate: %w", err)
+		c.root.ReportFailure("-", "musician", err)
+		return err
 	}
 
 	cfg := c.root.Cfg
 	if cfg.Accounts == nil {
-		return fmt.Errorf("配置文件中缺少 accounts 账号节点")
+		err := fmt.Errorf("配置文件中缺少 accounts 账号节点")
+		c.root.ReportFailure("-", "musician", err)
+		return err
 	}
 
 	var activeAccounts []struct {
@@ -308,6 +312,7 @@ func (c *Musician) execute(ctx context.Context) error {
 
 	if len(activeAccounts) == 0 {
 		c.cmd.Println("[musician] 未启用或未配置任何账号进行音乐人任务，请检查 config.yaml")
+		c.root.ReportSkip("-", "musician", "未启用或未配置任何账号")
 		return nil
 	}
 
@@ -316,11 +321,13 @@ func (c *Musician) execute(ctx context.Context) error {
 			c.cmd.Printf("[musician] >>>>>> 开始主账号音乐人任务 (%s) <<<<<<\n", acc.Filepath)
 			if err := c.runMusicianForCookie(ctx, acc.Filepath, true); err != nil {
 				c.cmd.Printf("[musician] ❌ 主账号任务失败: %s\n", err)
+				c.root.ReportFailure(acc.Filepath, "musician", err)
 			}
 		} else {
 			c.cmd.Printf("[musician] >>>>>> 开始辅助账号音乐人任务 (%s) <<<<<<\n", acc.Filepath)
 			if err := c.runMusicianForCookie(ctx, acc.Filepath, false); err != nil {
 				c.cmd.Printf("[musician] ❌ 辅助账号任务失败: %s\n", err)
+				c.root.ReportFailure(acc.Filepath, "musician", err)
 			}
 		}
 
@@ -363,12 +370,16 @@ func (c *Musician) runMusicianForCookie(ctx context.Context, cookieFile string, 
 
 func (c *Musician) executeSign(ctx context.Context) error {
 	if err := c.validate(); err != nil {
-		return fmt.Errorf("validate: %w", err)
+		err = fmt.Errorf("validate: %w", err)
+		c.root.ReportFailure("-", "musician-sign", err)
+		return err
 	}
 
 	cfg := c.root.Cfg
 	if cfg.Accounts == nil {
-		return fmt.Errorf("配置文件中缺少 accounts 账号节点")
+		err := fmt.Errorf("配置文件中缺少 accounts 账号节点")
+		c.root.ReportFailure("-", "musician-sign", err)
+		return err
 	}
 
 	var hasExecuted bool
@@ -378,6 +389,7 @@ func (c *Musician) executeSign(ctx context.Context) error {
 		c.cmd.Printf("[musician sign] >>>>>> 开始主账号音乐人日常签到 (%s) <<<<<<\n", cfg.Accounts.Main)
 		if err := c.RunSignForCookie(ctx, cfg.Accounts.Main); err != nil {
 			c.cmd.Printf("[musician sign] ❌ 主账号签到失败: %s\n", err)
+			c.root.ReportFailure(cfg.Accounts.Main, "musician-sign", err)
 		}
 		hasExecuted = true
 	} else {
@@ -394,6 +406,7 @@ func (c *Musician) executeSign(ctx context.Context) error {
 			c.cmd.Printf("[musician sign] >>>>>> 开始辅助账号音乐人日常签到 (%s) <<<<<<\n", secCookie)
 			if err := c.RunSignForCookie(ctx, secCookie); err != nil {
 				c.cmd.Printf("[musician sign] ❌ 辅助账号签到失败: %s\n", err)
+				c.root.ReportFailure(secCookie, "musician-sign", err)
 			}
 			hasExecuted = true
 		}
@@ -407,6 +420,7 @@ func (c *Musician) executeSign(ctx context.Context) error {
 
 	if !hasExecuted {
 		c.cmd.Println("[musician sign] 未启用或未配置任何账号进行音乐人签到，请检查 config.yaml")
+		c.root.ReportSkip("-", "musician-sign", "未启用或未配置任何账号")
 	} else {
 		c.cmd.Println("[musician sign] 所有音乐人日常签到任务执行完毕！")
 	}
@@ -429,12 +443,16 @@ func (c *Musician) RunSignForCookie(ctx context.Context, cookieFile string) erro
 
 func (c *Musician) executeVip(ctx context.Context) error {
 	if err := c.validate(); err != nil {
-		return fmt.Errorf("validate: %w", err)
+		err = fmt.Errorf("validate: %w", err)
+		c.root.ReportFailure("-", "musician-vip", err)
+		return err
 	}
 
 	cfg := c.root.Cfg
 	if cfg.Accounts == nil {
-		return fmt.Errorf("配置文件中缺少 accounts 账号节点")
+		err := fmt.Errorf("配置文件中缺少 accounts 账号节点")
+		c.root.ReportFailure("-", "musician-vip", err)
+		return err
 	}
 
 	var hasExecuted bool
@@ -444,6 +462,7 @@ func (c *Musician) executeVip(ctx context.Context) error {
 		c.cmd.Printf("[musician vip] >>>>>> 开始主账号音乐人VIP进阶任务 (%s) <<<<<<\n", cfg.Accounts.Main)
 		if err := c.RunVipForCookie(ctx, cfg.Accounts.Main); err != nil {
 			c.cmd.Printf("[musician vip] ❌ 主账号VIP任务失败: %s\n", err)
+			c.root.ReportFailure(cfg.Accounts.Main, "musician-vip", err)
 		}
 		hasExecuted = true
 	} else {
@@ -460,6 +479,7 @@ func (c *Musician) executeVip(ctx context.Context) error {
 			c.cmd.Printf("[musician vip] >>>>>> 开始辅助账号音乐人VIP进阶任务 (%s) <<<<<<\n", secCookie)
 			if err := c.RunVipForCookie(ctx, secCookie); err != nil {
 				c.cmd.Printf("[musician vip] ❌ 辅助账号VIP任务失败: %s\n", err)
+				c.root.ReportFailure(secCookie, "musician-vip", err)
 			}
 			hasExecuted = true
 		}
@@ -473,6 +493,7 @@ func (c *Musician) executeVip(ctx context.Context) error {
 
 	if !hasExecuted {
 		c.cmd.Println("[musician vip] 未启用或未配置任何账号进行音乐人VIP任务，请检查 config.yaml")
+		c.root.ReportSkip("-", "musician-vip", "未启用或未配置任何账号")
 	} else {
 		c.cmd.Println("[musician vip] 所有音乐人VIP进阶任务执行完毕！")
 	}

--- a/internal/ncmm/ncmm.go
+++ b/internal/ncmm/ncmm.go
@@ -8,9 +8,11 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/3899/ncmm/config"
 	"github.com/3899/ncmm/pkg/log"
+	"github.com/3899/ncmm/pkg/notify"
 	"github.com/3899/ncmm/pkg/utils"
 
 	"github.com/spf13/cobra"
@@ -31,6 +33,10 @@ type Root struct {
 	cmd        *cobra.Command
 	l          *log.Logger
 	AppVersion string
+	// Report collects failures/skips for end-of-run notify summary.
+	Report *notify.Report
+	// Notifier is nil when notify is disabled or no channels are configured.
+	Notifier *notify.Dispatcher
 }
 
 func New() *Root {
@@ -98,12 +104,25 @@ func New() *Root {
 		log.Default = c.l
 		log.Debug("[config] init home=%s path=%s log=%+v network=%+v", home, cfgPath, c.Cfg.Log, c.Cfg.Network)
 
+		c.initNotify()
+		if c.Report != nil {
+			// Prefer the leaf command path, e.g. "ncmm task" / "ncmm musician sign"
+			c.Report.SetCommand(strings.TrimSpace(cmd.CommandPath()))
+		}
+
 		c.CheckForUpdatesPreRun()
 		return nil
 	}
 	c.cmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
+		if c.Report != nil {
+			c.Report.SetCommand(strings.TrimSpace(cmd.CommandPath()))
+		}
+		c.FlushNotify(strings.TrimSpace(cmd.CommandPath()))
 		c.ShowUpdateNotificationPostRun()
-		return c.l.Close()
+		if c.l != nil {
+			return c.l.Close()
+		}
+		return nil
 	}
 
 	c.addFlags()

--- a/internal/ncmm/note.go
+++ b/internal/ncmm/note.go
@@ -58,10 +58,15 @@ func (c *Note) execute(ctx context.Context) error {
 		if c.root.Cfg.Accounts != nil && c.root.Cfg.Accounts.Main != "" {
 			cookieFile = c.root.Cfg.Accounts.Main
 		} else {
-			return fmt.Errorf("cookie file must be specified via --cookie-file or configured in config.yaml accounts.main")
+			err := fmt.Errorf("cookie file must be specified via --cookie-file or configured in config.yaml accounts.main")
+			c.root.ReportFailure("-", "note", err)
+			return err
 		}
 	}
 	_, err := c.ExecuteForCookie(ctx, cookieFile)
+	if err != nil {
+		c.root.ReportFailure(cookieFile, "note", err)
+	}
 	return err
 }
 

--- a/internal/ncmm/notify.go
+++ b/internal/ncmm/notify.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 @3899. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
+
+package ncmm
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/3899/ncmm/pkg/log"
+	"github.com/3899/ncmm/pkg/notify"
+)
+
+// initNotify prepares report collector and optional channel dispatcher from config.
+func (c *Root) initNotify() {
+	c.Report = notify.NewReport("ncmm")
+	c.Notifier = nil
+
+	if c.Cfg == nil || c.Cfg.Notify == nil || !c.Cfg.Notify.Enabled {
+		return
+	}
+
+	path := resolveNotifyFilePath(c.CfgPath, c.Opts.Home, c.Cfg.Notify.File)
+	cfg, fileMissing, err := notify.LoadChannels(path)
+	if err != nil {
+		log.Warn("[notify] load channels file failed (%s): %v", path, err)
+		return
+	}
+	if fileMissing {
+		log.Warn("[notify] channels file not found: %s (env overrides still applied if set)", path)
+	}
+
+	timeout := notify.ParseTimeout(c.Cfg.Notify.Timeout)
+	d := notify.NewDispatcher(cfg, timeout)
+	if d.Len() == 0 {
+		log.Warn("[notify] enabled but no valid channel configured (file=%s)", path)
+		return
+	}
+	c.Notifier = d
+	if fileMissing {
+		log.Info("[notify] loaded %d channel(s) from environment", d.Len())
+	} else {
+		log.Info("[notify] loaded %d channel(s) from %s", d.Len(), path)
+	}
+}
+
+func resolveNotifyFilePath(cfgPath, home, file string) string {
+	file = strings.TrimSpace(file)
+	if file == "" {
+		file = "notify.yaml"
+	}
+	if filepath.IsAbs(file) {
+		return filepath.Clean(file)
+	}
+	if cfgPath != "" && cfgPath != "default" {
+		return filepath.Clean(filepath.Join(filepath.Dir(cfgPath), file))
+	}
+	if home == "" {
+		home = "."
+	}
+	return filepath.Clean(filepath.Join(home, file))
+}
+
+// ReportFailure records a failure for end-of-run notification.
+func (c *Root) ReportFailure(account, task string, err error) {
+	if c == nil || c.Report == nil || err == nil {
+		return
+	}
+	c.Report.AddFailure(account, task, err)
+}
+
+// ReportFailureMsg records a failure message.
+func (c *Root) ReportFailureMsg(account, task, message string) {
+	if c == nil || c.Report == nil {
+		return
+	}
+	c.Report.AddFailureMsg(account, task, message)
+}
+
+// ReportSkip records a skipped task for end-of-run notification.
+func (c *Root) ReportSkip(account, task, reason string) {
+	if c == nil || c.Report == nil {
+		return
+	}
+	c.Report.AddSkip(account, task, reason)
+}
+
+// FlushNotify sends aggregated failure/skip summary if needed.
+// Notification errors are logged only and never returned.
+func (c *Root) FlushNotify(command string) {
+	if c == nil || c.Report == nil {
+		return
+	}
+	if command != "" {
+		c.Report.SetCommand(command)
+	}
+	if c.Cfg == nil || c.Cfg.Notify == nil || !c.Cfg.Notify.Enabled {
+		return
+	}
+	onSkip := c.Cfg.Notify.OnSkipEnabled()
+	if !c.Report.NeedNotify(onSkip) {
+		return
+	}
+	if c.Notifier == nil || c.Notifier.Len() == 0 {
+		log.Warn("[notify] has events to push but no channel available")
+		return
+	}
+
+	title, content := c.Report.Summary(c.Cfg.Notify.TitlePrefix, onSkip)
+	msg := notify.Message{
+		Title:   title,
+		Content: content,
+		Level:   "error",
+	}
+	if err := c.Notifier.SendAll(context.Background(), msg); err != nil {
+		log.Warn("[notify] send failed: %v", err)
+		return
+	}
+	log.Info("[notify] summary sent: %s", title)
+}
+

--- a/internal/ncmm/playids.go
+++ b/internal/ncmm/playids.go
@@ -235,7 +235,9 @@ func (c *PlayIds) execute(ctx context.Context) error {
 		// 未指定参数，根据配置文件开关选取账号
 		cfg := c.root.Cfg
 		if cfg.Accounts == nil {
-			return fmt.Errorf("配置文件中缺少 accounts 账号节点")
+			err := fmt.Errorf("配置文件中缺少 accounts 账号节点")
+			c.root.ReportFailure("-", "playids", err)
+			return err
 		}
 		if cfg.PlayIds != nil && cfg.PlayIds.EnableMain && cfg.Accounts.Main != "" {
 			executeQueue = append(executeQueue, cfg.Accounts.Main)
@@ -259,6 +261,7 @@ func (c *PlayIds) execute(ctx context.Context) error {
 
 	if len(executeQueue) == 0 {
 		c.log("未启用或未配置任何账号执行模拟播放打卡，请检查 config.yaml")
+		c.root.ReportSkip("-", "playids", "未启用或未配置任何账号")
 		return nil
 	}
 
@@ -267,6 +270,7 @@ func (c *PlayIds) execute(ctx context.Context) error {
 		c.log(">>>>>> 开始为账号 (%s) 执行模拟播放 <<<<<<", cookieFile)
 		if _, err := c.executeForCookie(ctx, cookieFile, uniqueIds); err != nil {
 			c.log("[ERROR] 账号 (%s) 模拟播放失败: %s", cookieFile, err)
+			c.root.ReportFailure(cookieFile, "playids", err)
 		}
 		c.log("--------------------------------------------------\n")
 

--- a/internal/ncmm/sign.go
+++ b/internal/ncmm/sign.go
@@ -84,12 +84,16 @@ func (c *SignIn) sleepBetweenAccounts(ctx context.Context, currentAccount string
 
 func (c *SignIn) execute(ctx context.Context) error {
 	if err := c.validate(); err != nil {
-		return fmt.Errorf("validate: %w", err)
+		err = fmt.Errorf("validate: %w", err)
+		c.root.ReportFailure("-", "sign", err)
+		return err
 	}
 
 	cfg := c.root.Cfg
 	if cfg.Accounts == nil {
-		return fmt.Errorf("配置文件中缺少 accounts 账号节点")
+		err := fmt.Errorf("配置文件中缺少 accounts 账号节点")
+		c.root.ReportFailure("-", "sign", err)
+		return err
 	}
 
 	var activeAccounts []struct {
@@ -136,11 +140,13 @@ func (c *SignIn) execute(ctx context.Context) error {
 			c.cmd.Printf("[sign] >>>>>> 开始主账号签到 (%s) <<<<<<\n", acc.Filepath)
 			if err := c.RunSignForCookie(ctx, acc.Filepath, true, nil); err != nil {
 				c.cmd.Printf("[sign] ❌ 主账号签到失败: %s\n", err)
+				c.root.ReportFailure(acc.Filepath, "sign", err)
 			}
 		} else {
 			c.cmd.Printf("[sign] >>>>>> 开始辅助账号签到 (%s) <<<<<<\n", acc.Filepath)
 			if err := c.RunSignForCookie(ctx, acc.Filepath, false, nil); err != nil {
 				c.cmd.Printf("[sign] ❌ 辅助账号签到失败: %s\n", err)
+				c.root.ReportFailure(acc.Filepath, "sign", err)
 			}
 		}
 

--- a/internal/ncmm/task.go
+++ b/internal/ncmm/task.go
@@ -216,7 +216,31 @@ func (c *Task) sleepBetweenAccounts(ctx context.Context, currentAccount string) 
 	}
 }
 
-func (c *Task) executeAction(ctx context.Context, stdAction string, account Account, queue []string, activeTasks map[string]bool, signRunMap map[string]bool) bool {
+// isSessionInvalidError 判断错误是否为 Cookie/会话失效，此类错误应跳过该账号后续任务。
+func isSessionInvalidError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	patterns := []string{
+		"cookie 已失效",
+		"需要登录",
+		"need login",
+		"not logged in",
+		"session expired",
+		"user not logged in",
+	}
+	for _, p := range patterns {
+		if strings.Contains(msg, strings.ToLower(p)) {
+			return true
+		}
+	}
+	return false
+}
+
+// executeAction runs one task action. sessionInvalid is true when the cookie/session is dead
+// and remaining tasks for this account should be skipped.
+func (c *Task) executeAction(ctx context.Context, stdAction string, account Account, queue []string, activeTasks map[string]bool, signRunMap map[string]bool) (executed bool, sessionInvalid bool) {
 	isSignSubtask := false
 	signSubtasks := []string{
 		"VipTask", "Reserve", "ViewVipCenter", "LikeComment", "FollowArtist",
@@ -230,7 +254,6 @@ func (c *Task) executeAction(ctx context.Context, stdAction string, account Acco
 	}
 
 	if isSignSubtask {
-		var executed bool
 		if !signRunMap[account.Filepath] {
 			allowedTasks := make(map[string]bool)
 			for _, qItem := range queue {
@@ -246,6 +269,8 @@ func (c *Task) executeAction(ctx context.Context, stdAction string, account Acco
 				s := NewSign(c.root, c.l)
 				if err := s.RunSignForCookie(ctx, account.Filepath, account.IsMain, allowedTasks); err != nil {
 					c.cmd.Printf("[task] ❌ 账号 (%s) [日常签到] 执行失败: %s\n", account.Filepath, err)
+					c.root.ReportFailure(account.Filepath, "sign", err)
+					sessionInvalid = isSessionInvalidError(err)
 				} else {
 					c.cmd.Printf("[task] ✅ 账号 (%s) [日常签到] 执行完毕\n", account.Filepath)
 				}
@@ -254,7 +279,7 @@ func (c *Task) executeAction(ctx context.Context, stdAction string, account Acco
 			}
 			signRunMap[account.Filepath] = true
 		}
-		return executed
+		return executed, sessionInvalid
 	}
 
 	if stdAction == "playids" {
@@ -262,11 +287,13 @@ func (c *Task) executeAction(ctx context.Context, stdAction string, account Acco
 		p := NewPlayIds(c.root, c.l)
 		if err := p.RunForCookie(ctx, account.Filepath); err != nil {
 			c.cmd.Printf("[task] ❌ 账号 (%s) [播放指定歌曲] 执行失败: %s\n", account.Filepath, err)
+			c.root.ReportFailure(account.Filepath, "playids", err)
+			sessionInvalid = isSessionInvalidError(err)
 		} else {
 			c.cmd.Printf("[task] ✅ 账号 (%s) [播放指定歌曲] 执行完毕\n", account.Filepath)
 		}
 		c.sleepBetweenTasks(ctx)
-		return true
+		return true, sessionInvalid
 	}
 
 	if stdAction == "musician-sign" {
@@ -274,11 +301,13 @@ func (c *Task) executeAction(ctx context.Context, stdAction string, account Acco
 		m := NewMusician(c.root, c.l)
 		if err := m.RunSignForCookie(ctx, account.Filepath); err != nil {
 			c.cmd.Printf("[task] ❌ 账号 (%s) [音乐人日常签到] 执行失败: %s\n", account.Filepath, err)
+			c.root.ReportFailure(account.Filepath, "musician-sign", err)
+			sessionInvalid = isSessionInvalidError(err)
 		} else {
 			c.cmd.Printf("[task] ✅ 账号 (%s) [音乐人日常签到] 执行完毕\n", account.Filepath)
 		}
 		c.sleepBetweenTasks(ctx)
-		return true
+		return true, sessionInvalid
 	}
 
 	if stdAction == "musician-vip" {
@@ -286,11 +315,13 @@ func (c *Task) executeAction(ctx context.Context, stdAction string, account Acco
 		m := NewMusician(c.root, c.l)
 		if err := m.RunVipForCookie(ctx, account.Filepath); err != nil {
 			c.cmd.Printf("[task] ❌ 账号 (%s) [音乐人VIP进阶] 执行失败: %s\n", account.Filepath, err)
+			c.root.ReportFailure(account.Filepath, "musician-vip", err)
+			sessionInvalid = isSessionInvalidError(err)
 		} else {
 			c.cmd.Printf("[task] ✅ 账号 (%s) [音乐人VIP进阶] 执行完毕\n", account.Filepath)
 		}
 		c.sleepBetweenTasks(ctx)
-		return true
+		return true, sessionInvalid
 	}
 
 	if stdAction == "note" {
@@ -298,11 +329,13 @@ func (c *Task) executeAction(ctx context.Context, stdAction string, account Acco
 		n := NewNote(c.root, c.l)
 		if _, err := n.ExecuteForCookie(ctx, account.Filepath); err != nil {
 			c.cmd.Printf("[task] ❌ 账号 (%s) [发布图文动态] 执行失败: %s\n", account.Filepath, err)
+			c.root.ReportFailure(account.Filepath, "note", err)
+			sessionInvalid = isSessionInvalidError(err)
 		} else {
 			c.cmd.Printf("[task] ✅ 账号 (%s) [发布图文动态] 执行完毕\n", account.Filepath)
 		}
 		c.sleepBetweenTasks(ctx)
-		return true
+		return true, sessionInvalid
 	}
 
 	if stdAction == "daily-song-share" {
@@ -311,19 +344,28 @@ func (c *Task) executeAction(ctx context.Context, stdAction string, account Acco
 		cfg, err := d.getConfig()
 		if err != nil {
 			c.cmd.Printf("[task] account (%s) [daily song share] skipped: %s\n", account.Filepath, err)
-			return false
+			c.root.ReportSkip(account.Filepath, "daily-song-share", err.Error())
+			return false, false
 		}
 		if err := d.validatePrerequisites(cfg); err != nil {
 			c.cmd.Printf("[task] account (%s) [daily song share] skipped: %s\n", account.Filepath, err)
-			return false
+			c.root.ReportSkip(account.Filepath, "daily-song-share", err.Error())
+			return false, false
 		}
 		if _, err := d.ExecuteForCookie(ctx, account.Filepath); err != nil {
 			c.cmd.Printf("[task] account (%s) [daily song share] failed: %s\n", account.Filepath, err)
+			// missing token is operational skip rather than hard failure
+			if strings.Contains(err.Error(), "跳过") || strings.Contains(strings.ToLower(err.Error()), "skip") {
+				c.root.ReportSkip(account.Filepath, "daily-song-share", err.Error())
+			} else {
+				c.root.ReportFailure(account.Filepath, "daily-song-share", err)
+				sessionInvalid = isSessionInvalidError(err)
+			}
 		} else {
 			c.cmd.Printf("[task] account (%s) [daily song share] done\n", account.Filepath)
 		}
 		c.sleepBetweenTasks(ctx)
-		return true
+		return true, sessionInvalid
 	}
 
 	if stdAction == "vip-member-gift" {
@@ -332,19 +374,27 @@ func (c *Task) executeAction(ctx context.Context, stdAction string, account Acco
 		cfg, err := v.getConfig()
 		if err != nil {
 			c.cmd.Printf("[task] account (%s) [vip member gift] skipped: %s\n", account.Filepath, err)
-			return false
+			c.root.ReportSkip(account.Filepath, "vip-member-gift", err.Error())
+			return false, false
 		}
 		if err := v.validateCommonPrerequisites(cfg); err != nil {
 			c.cmd.Printf("[task] account (%s) [vip member gift] skipped: %s\n", account.Filepath, err)
-			return false
+			c.root.ReportSkip(account.Filepath, "vip-member-gift", err.Error())
+			return false, false
 		}
 		if err := v.ExecuteForCookie(ctx, account.Filepath); err != nil {
 			c.cmd.Printf("[task] account (%s) [vip member gift] failed: %s\n", account.Filepath, err)
+			if strings.Contains(err.Error(), "跳过") || strings.Contains(strings.ToLower(err.Error()), "skip") {
+				c.root.ReportSkip(account.Filepath, "vip-member-gift", err.Error())
+			} else {
+				c.root.ReportFailure(account.Filepath, "vip-member-gift", err)
+				sessionInvalid = isSessionInvalidError(err)
+			}
 		} else {
 			c.cmd.Printf("[task] account (%s) [vip member gift] done\n", account.Filepath)
 		}
 		c.sleepBetweenTasks(ctx)
-		return true
+		return true, sessionInvalid
 	}
 
 	if stdAction == "fansgroup" {
@@ -352,22 +402,37 @@ func (c *Task) executeAction(ctx context.Context, stdAction string, account Acco
 		f := NewFansGroup(c.root, c.l)
 		if err := f.ExecuteForCookie(ctx, account.Filepath); err != nil {
 			c.cmd.Printf("[task] ❌ 账号 (%s) [乐迷团任务] 执行失败: %s\n", account.Filepath, err)
+			c.root.ReportFailure(account.Filepath, "fansgroup", err)
+			sessionInvalid = isSessionInvalidError(err)
 		} else {
 			c.cmd.Printf("[task] ✅ 账号 (%s) [乐迷团任务] 执行完毕\n", account.Filepath)
 		}
 		c.sleepBetweenTasks(ctx)
-		return true
+		return true, sessionInvalid
 	}
-	return false
+	return false, false
 }
 
-func (c *Task) runQueue(ctx context.Context, queue []string, accounts []Account, activeTasks map[string]bool) bool {
+// runQueue executes a task queue. invalidSessions is shared across fast/slow queues for the whole run.
+func (c *Task) runQueue(ctx context.Context, queue []string, accounts []Account, activeTasks map[string]bool, invalidSessions map[string]bool) bool {
+	if invalidSessions == nil {
+		invalidSessions = make(map[string]bool)
+	}
 	signRunMap := make(map[string]bool)
 	var queueExecuted bool
 
 	for i, account := range accounts {
+		if invalidSessions[account.Filepath] {
+			c.cmd.Printf("[task] ⚠️ 账号 (%s) Cookie/会话已失效，跳过本队列全部任务\n", account.Filepath)
+			continue
+		}
+
 		var hasExecuted bool
 		for _, action := range queue {
+			if invalidSessions[account.Filepath] {
+				break
+			}
+
 			stdAction := c.standardizeActionKey(action)
 			if stdAction == "" {
 				continue
@@ -381,9 +446,15 @@ func (c *Task) runQueue(ctx context.Context, queue []string, accounts []Account,
 				continue
 			}
 
-			if c.executeAction(ctx, stdAction, account, queue, activeTasks, signRunMap) {
+			executed, sessionInvalid := c.executeAction(ctx, stdAction, account, queue, activeTasks, signRunMap)
+			if executed {
 				hasExecuted = true
 				queueExecuted = true
+			}
+			if sessionInvalid {
+				invalidSessions[account.Filepath] = true
+				c.cmd.Printf("[task] ⚠️ 账号 (%s) Cookie/会话已失效，跳过该账号后续任务\n", account.Filepath)
+				break
 			}
 		}
 		if hasExecuted && i < len(accounts)-1 {
@@ -478,17 +549,19 @@ func (c *Task) execute(ctx context.Context) error {
 
 	fastQueue := cfg.Task.FastTasks
 	slowQueue := cfg.Task.SlowTasks
+	// 整次 task 进程共享：同一账号 Cookie 失效后，快/慢任务组均不再继续执行该账号
+	invalidSessions := make(map[string]bool)
 
 	if mode == "by-task-group" {
 		if runFast {
 			c.cmd.Println("[task] >>>>>> 开始执行 [快任务组] (跨账号串行) <<<<<<")
-			c.runQueue(ctx, fastQueue, accounts, activeTasks)
+			c.runQueue(ctx, fastQueue, accounts, activeTasks, invalidSessions)
 			c.cmd.Printf("[task] >>>>>> [快任务组] 执行完毕 <<<<<<\n\n")
 		}
 
 		if runSlow {
 			c.cmd.Println("[task] >>>>>> 开始执行 [慢任务组] (跨账号串行) <<<<<<")
-			c.runQueue(ctx, slowQueue, accounts, activeTasks)
+			c.runQueue(ctx, slowQueue, accounts, activeTasks, invalidSessions)
 			c.cmd.Printf("[task] >>>>>> [慢任务组] 执行完毕 <<<<<<\n\n")
 		}
 	} else if mode == "by-account" {
@@ -497,13 +570,13 @@ func (c *Task) execute(ctx context.Context) error {
 			var hasExecuted bool
 			if runFast {
 				c.cmd.Println("  --- [快任务组] ---")
-				if c.runQueue(ctx, fastQueue, []Account{account}, activeTasks) {
+				if c.runQueue(ctx, fastQueue, []Account{account}, activeTasks, invalidSessions) {
 					hasExecuted = true
 				}
 			}
 			if runSlow {
 				c.cmd.Println("  --- [慢任务组] ---")
-				if c.runQueue(ctx, slowQueue, []Account{account}, activeTasks) {
+				if c.runQueue(ctx, slowQueue, []Account{account}, activeTasks, invalidSessions) {
 					hasExecuted = true
 				}
 			}

--- a/internal/ncmm/vip_member_gift.go
+++ b/internal/ncmm/vip_member_gift.go
@@ -142,14 +142,17 @@ func (c *VipMemberGift) getConfig() (*config.VipMemberGiftConf, error) {
 func (c *VipMemberGift) execute(ctx context.Context) error {
 	cfg, err := c.getConfig()
 	if err != nil {
+		c.root.ReportFailure("-", "vip-member-gift", err)
 		return err
 	}
 	if !cfg.EnableGift && !cfg.EnableClaim {
 		c.cmd.Println("[vip-member-gift] skipped: enableGift and enableClaim are both false")
+		c.root.ReportSkip("-", "vip-member-gift", "enableGift and enableClaim are both false")
 		return nil
 	}
 	if err := c.validateCommonPrerequisites(cfg); err != nil {
 		c.cmd.Printf("[vip-member-gift] skipped: %v\n", err)
+		c.root.ReportSkip("-", "vip-member-gift", err.Error())
 		return nil
 	}
 
@@ -159,6 +162,7 @@ func (c *VipMemberGift) execute(ctx context.Context) error {
 	} else {
 		if c.root.Cfg.Accounts == nil {
 			c.cmd.Println("[vip-member-gift] no accounts configured, please check config.yaml")
+			c.root.ReportSkip("-", "vip-member-gift", "no accounts configured")
 			return nil
 		}
 		if cfg.EnableMain && c.root.Cfg.Accounts.Main != "" {
@@ -175,6 +179,7 @@ func (c *VipMemberGift) execute(ctx context.Context) error {
 
 	if len(queue) == 0 {
 		c.cmd.Println("[vip-member-gift] no available accounts, please check config.yaml")
+		c.root.ReportSkip("-", "vip-member-gift", "no available accounts")
 		return nil
 	}
 
@@ -182,6 +187,11 @@ func (c *VipMemberGift) execute(ctx context.Context) error {
 		c.cmd.Printf("[vip-member-gift] start account (%s)\n", cookieFile)
 		if err := c.ExecuteForCookie(ctx, cookieFile); err != nil {
 			c.cmd.Printf("[vip-member-gift] account failed (%s): %v\n", cookieFile, err)
+			if strings.Contains(err.Error(), "跳过") || strings.Contains(strings.ToLower(err.Error()), "skip") {
+				c.root.ReportSkip(cookieFile, "vip-member-gift", err.Error())
+			} else {
+				c.root.ReportFailure(cookieFile, "vip-member-gift", err)
+			}
 		}
 		c.cmd.Println("[vip-member-gift] --------------------------------------------------")
 		if i < len(queue)-1 {

--- a/pkg/notify/channels.go
+++ b/pkg/notify/channels.go
@@ -1,0 +1,510 @@
+// Copyright (c) 2026 @3899. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
+
+package notify
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ---------- Webhook ----------
+
+type webhookChannel struct {
+	cfg    WebhookConfig
+	client *http.Client
+}
+
+func (c *webhookChannel) Name() string { return "webhook" }
+
+func (c *webhookChannel) Send(ctx context.Context, msg Message) error {
+	method := strings.ToUpper(strings.TrimSpace(c.cfg.Method))
+	if method == "" {
+		method = http.MethodPost
+	}
+	body, contentType, err := buildWebhookBody(c.cfg.BodyTemplate, msg)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.cfg.URL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	for k, v := range c.cfg.Headers {
+		if strings.TrimSpace(k) != "" {
+			req.Header.Set(k, v)
+		}
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("http status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func buildWebhookBody(template string, msg Message) ([]byte, string, error) {
+	host, _ := os.Hostname()
+	now := time.Now().Format(time.RFC3339)
+	if strings.TrimSpace(template) == "" {
+		payload := map[string]string{
+			"title":   msg.Title,
+			"content": msg.Content,
+			"level":   msg.Level,
+			"time":    now,
+			"host":    host,
+		}
+		b, err := json.Marshal(payload)
+		return b, "application/json", err
+	}
+	replacer := strings.NewReplacer(
+		"{{title}}", msg.Title,
+		"{{content}}", msg.Content,
+		"{{level}}", msg.Level,
+		"{{time}}", now,
+		"{{host}}", host,
+	)
+	out := replacer.Replace(template)
+	return []byte(out), "application/json", nil
+}
+
+// ---------- Bark ----------
+
+type barkChannel struct {
+	cfg    BarkConfig
+	client *http.Client
+}
+
+func (c *barkChannel) Name() string { return "bark" }
+
+func (c *barkChannel) Send(ctx context.Context, msg Message) error {
+	server := strings.TrimRight(strings.TrimSpace(c.cfg.Server), "/")
+	if server == "" {
+		server = "https://api.day.app"
+	}
+	u := fmt.Sprintf("%s/%s/%s/%s",
+		server,
+		url.PathEscape(c.cfg.Key),
+		url.PathEscape(msg.Title),
+		url.PathEscape(msg.Content),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var result struct {
+		Code int `json:"code"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("http status %d", resp.StatusCode)
+	}
+	if result.Code != 0 && result.Code != 200 {
+		return fmt.Errorf("bark code %d", result.Code)
+	}
+	return nil
+}
+
+// ---------- Server酱 ----------
+
+type serverChanChannel struct {
+	cfg    ServerChanConfig
+	client *http.Client
+}
+
+func (c *serverChanChannel) Name() string { return "serverchan" }
+
+func (c *serverChanChannel) Send(ctx context.Context, msg Message) error {
+	key := strings.TrimSpace(c.cfg.SCKEY)
+	var endpoint string
+	if strings.HasPrefix(strings.ToUpper(key), "SCT") {
+		endpoint = fmt.Sprintf("https://sctapi.ftqq.com/%s.send", url.PathEscape(key))
+	} else {
+		endpoint = fmt.Sprintf("https://sc.ftqq.com/%s.send", url.PathEscape(key))
+	}
+	form := url.Values{}
+	form.Set("text", msg.Title)
+	form.Set("desp", strings.ReplaceAll(msg.Content, "\n", "\n\n"))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("http status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// ---------- Telegram ----------
+
+type telegramChannel struct {
+	cfg     TelegramConfig
+	client  *http.Client
+	timeout time.Duration
+}
+
+func (c *telegramChannel) Name() string { return "telegram" }
+
+func (c *telegramChannel) Send(ctx context.Context, msg Message) error {
+	apiHost := strings.TrimSpace(c.cfg.APIHost)
+	var base string
+	switch {
+	case apiHost == "":
+		base = "https://api.telegram.org"
+	case strings.HasPrefix(apiHost, "http://") || strings.HasPrefix(apiHost, "https://"):
+		base = strings.TrimRight(apiHost, "/")
+	default:
+		base = "https://" + strings.TrimRight(apiHost, "/")
+	}
+	endpoint := fmt.Sprintf("%s/bot%s/sendMessage", base, c.cfg.BotToken)
+
+	client := c.client
+	if proxy := strings.TrimSpace(c.cfg.Proxy); proxy != "" {
+		u, err := url.Parse(proxy)
+		if err != nil {
+			return fmt.Errorf("invalid telegram proxy: %w", err)
+		}
+		client = &http.Client{
+			Timeout: c.timeout,
+			Transport: &http.Transport{
+				Proxy: http.ProxyURL(u),
+			},
+		}
+	}
+
+	form := url.Values{}
+	form.Set("chat_id", c.cfg.UserID)
+	form.Set("text", msg.Title+"\n\n"+msg.Content)
+	form.Set("disable_web_page_preview", "true")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var result struct {
+		OK          bool   `json:"ok"`
+		Description string `json:"description"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+	if !result.OK {
+		if result.Description != "" {
+			return fmt.Errorf("telegram: %s", result.Description)
+		}
+		return fmt.Errorf("telegram send failed")
+	}
+	return nil
+}
+
+// ---------- DingTalk ----------
+
+type dingTalkChannel struct {
+	cfg    DingTalkConfig
+	client *http.Client
+}
+
+func (c *dingTalkChannel) Name() string { return "dingtalk" }
+
+func (c *dingTalkChannel) Send(ctx context.Context, msg Message) error {
+	endpoint := fmt.Sprintf("https://oapi.dingtalk.com/robot/send?access_token=%s", url.QueryEscape(c.cfg.AccessToken))
+	if secret := strings.TrimSpace(c.cfg.Secret); secret != "" {
+		ts := strconv.FormatInt(time.Now().UnixMilli(), 10)
+		stringToSign := ts + "\n" + secret
+		mac := hmac.New(sha256.New, []byte(secret))
+		_, _ = mac.Write([]byte(stringToSign))
+		sign := url.QueryEscape(base64.StdEncoding.EncodeToString(mac.Sum(nil)))
+		endpoint = fmt.Sprintf("%s&timestamp=%s&sign=%s", endpoint, ts, sign)
+	}
+	payload := map[string]any{
+		"msgtype": "text",
+		"text": map[string]string{
+			"content": msg.Title + "\n\n" + msg.Content,
+		},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json;charset=utf-8")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var result struct {
+		ErrCode int    `json:"errcode"`
+		ErrMsg  string `json:"errmsg"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+	if result.ErrCode != 0 {
+		return fmt.Errorf("dingtalk: %s (%d)", result.ErrMsg, result.ErrCode)
+	}
+	return nil
+}
+
+// ---------- CoolPush (QQ) ----------
+
+type coolPushChannel struct {
+	cfg    CoolPushConfig
+	client *http.Client
+}
+
+func (c *coolPushChannel) Name() string { return "coolpush" }
+
+func (c *coolPushChannel) Send(ctx context.Context, msg Message) error {
+	endpoint := fmt.Sprintf("https://qmsg.zendee.cn/%s/%s",
+		url.PathEscape(c.cfg.Mode), url.PathEscape(c.cfg.SKey))
+	form := url.Values{}
+	form.Set("msg", msg.Title+"\n\n"+msg.Content)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var result struct {
+		Code int    `json:"code"`
+		Reason string `json:"reason"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+	if result.Code != 0 {
+		if result.Reason != "" {
+			return fmt.Errorf("coolpush: %s", result.Reason)
+		}
+		return fmt.Errorf("coolpush code %d", result.Code)
+	}
+	return nil
+}
+
+// ---------- PushPlus ----------
+
+type pushPlusChannel struct {
+	cfg    PushPlusConfig
+	client *http.Client
+}
+
+func (c *pushPlusChannel) Name() string { return "pushplus" }
+
+func (c *pushPlusChannel) Send(ctx context.Context, msg Message) error {
+	payload := map[string]string{
+		"token":   c.cfg.Token,
+		"title":   msg.Title,
+		"content": msg.Content,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://www.pushplus.plus/send", bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var result struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+	if result.Code != 200 {
+		if result.Msg != "" {
+			return fmt.Errorf("pushplus: %s", result.Msg)
+		}
+		return fmt.Errorf("pushplus code %d", result.Code)
+	}
+	return nil
+}
+
+// ---------- WeCom group robot ----------
+
+type weComKeyChannel struct {
+	cfg    WeComKeyConfig
+	client *http.Client
+}
+
+func (c *weComKeyChannel) Name() string { return "wecom_key" }
+
+func (c *weComKeyChannel) Send(ctx context.Context, msg Message) error {
+	endpoint := fmt.Sprintf("https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=%s", url.QueryEscape(c.cfg.Key))
+	payload := map[string]any{
+		"msgtype": "text",
+		"text": map[string]string{
+			"content": msg.Title + "\n" + strings.ReplaceAll(msg.Content, "\n", "\n\n"),
+		},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var result struct {
+		ErrCode int    `json:"errcode"`
+		ErrMsg  string `json:"errmsg"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+	if result.ErrCode != 0 {
+		return fmt.Errorf("wecom_key: %s (%d)", result.ErrMsg, result.ErrCode)
+	}
+	return nil
+}
+
+// ---------- WeCom application ----------
+
+type weComAppChannel struct {
+	cfg    WeComAppConfig
+	client *http.Client
+}
+
+func (c *weComAppChannel) Name() string { return "wecom_app" }
+
+func (c *weComAppChannel) Send(ctx context.Context, msg Message) error {
+	token, err := c.getAccessToken(ctx)
+	if err != nil {
+		return err
+	}
+	endpoint := "https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token=" + url.QueryEscape(token)
+	toUser := strings.TrimSpace(c.cfg.ToUser)
+	if toUser == "" {
+		toUser = "@all"
+	}
+	agentID, err := strconv.Atoi(strings.TrimSpace(c.cfg.AgentID))
+	if err != nil {
+		return fmt.Errorf("invalid agent_id: %w", err)
+	}
+
+	var payload map[string]any
+	if mediaID := strings.TrimSpace(c.cfg.MediaID); mediaID != "" {
+		payload = map[string]any{
+			"touser":  toUser,
+			"msgtype": "mpnews",
+			"agentid": agentID,
+			"mpnews": map[string]any{
+				"articles": []map[string]string{
+					{
+						"title":              msg.Title,
+						"thumb_media_id":     mediaID,
+						"author":             "ncmm",
+						"content_source_url": "",
+						"content":            strings.ReplaceAll(msg.Content, "\n", "<br/>"),
+						"digest":             msg.Content,
+					},
+				},
+			},
+		}
+	} else {
+		payload = map[string]any{
+			"touser":  toUser,
+			"msgtype": "text",
+			"agentid": agentID,
+			"text": map[string]string{
+				"content": msg.Title + "\n\n" + msg.Content,
+			},
+			"safe": 0,
+		}
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var result struct {
+		ErrCode int    `json:"errcode"`
+		ErrMsg  string `json:"errmsg"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+	if result.ErrCode != 0 {
+		return fmt.Errorf("wecom_app: %s (%d)", result.ErrMsg, result.ErrCode)
+	}
+	return nil
+}
+
+func (c *weComAppChannel) getAccessToken(ctx context.Context) (string, error) {
+	u := "https://qyapi.weixin.qq.com/cgi-bin/gettoken?corpid=" + url.QueryEscape(c.cfg.CorpID) +
+		"&corpsecret=" + url.QueryEscape(c.cfg.CorpSecret)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	var result struct {
+		ErrCode     int    `json:"errcode"`
+		ErrMsg      string `json:"errmsg"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	if result.ErrCode != 0 || result.AccessToken == "" {
+		return "", fmt.Errorf("gettoken: %s (%d)", result.ErrMsg, result.ErrCode)
+	}
+	return result.AccessToken, nil
+}

--- a/pkg/notify/config.go
+++ b/pkg/notify/config.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 @3899. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
+
+package notify
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ChannelsConfig is the content of notify.yaml (channel credentials only).
+type ChannelsConfig struct {
+	Webhook    WebhookConfig    `yaml:"webhook"`
+	Bark       BarkConfig       `yaml:"bark"`
+	ServerChan ServerChanConfig `yaml:"serverchan"`
+	Telegram   TelegramConfig   `yaml:"telegram"`
+	DingTalk   DingTalkConfig   `yaml:"dingtalk"`
+	CoolPush   CoolPushConfig   `yaml:"coolpush"`
+	PushPlus   PushPlusConfig   `yaml:"pushplus"`
+	WeComKey   WeComKeyConfig   `yaml:"wecom_key"`
+	WeComApp   WeComAppConfig   `yaml:"wecom_app"`
+}
+
+type WebhookConfig struct {
+	Enabled      bool              `yaml:"enabled"`
+	URL          string            `yaml:"url"`
+	Method       string            `yaml:"method"`
+	Headers      map[string]string `yaml:"headers"`
+	BodyTemplate string            `yaml:"body_template"`
+}
+
+type BarkConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	Key     string `yaml:"key"`
+	Server  string `yaml:"server"` // empty => https://api.day.app
+}
+
+type ServerChanConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	SCKEY   string `yaml:"sckey"`
+}
+
+type TelegramConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	BotToken string `yaml:"bot_token"`
+	UserID   string `yaml:"user_id"`
+	APIHost  string `yaml:"api_host"`
+	Proxy    string `yaml:"proxy"` // e.g. http://127.0.0.1:7890
+}
+
+type DingTalkConfig struct {
+	Enabled     bool   `yaml:"enabled"`
+	AccessToken string `yaml:"access_token"`
+	Secret      string `yaml:"secret"`
+}
+
+type CoolPushConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	SKey    string `yaml:"skey"`
+	Mode    string `yaml:"mode"` // send / group / ...
+}
+
+type PushPlusConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	Token   string `yaml:"token"`
+}
+
+type WeComKeyConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	Key     string `yaml:"key"`
+}
+
+type WeComAppConfig struct {
+	Enabled    bool   `yaml:"enabled"`
+	CorpID     string `yaml:"corp_id"`
+	CorpSecret string `yaml:"corp_secret"`
+	ToUser     string `yaml:"to_user"`
+	AgentID    string `yaml:"agent_id"`
+	MediaID    string `yaml:"media_id"`
+}
+
+// LoadChannels reads notify.yaml and applies environment variable overrides.
+// If the file does not exist, returns an empty config with env overrides only
+// (fileMissing=true). Parse errors still return an error.
+func LoadChannels(path string) (cfg *ChannelsConfig, fileMissing bool, err error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			empty := &ChannelsConfig{}
+			applyEnvOverrides(empty)
+			return empty, true, nil
+		}
+		return nil, false, err
+	}
+	var parsed ChannelsConfig
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		return nil, false, fmt.Errorf("parse notify channels file: %w", err)
+	}
+	applyEnvOverrides(&parsed)
+	return &parsed, false, nil
+}
+
+func applyEnvOverrides(cfg *ChannelsConfig) {
+	if v := os.Getenv("NCMM_NOTIFY_WEBHOOK_URL"); v != "" {
+		cfg.Webhook.URL = v
+		cfg.Webhook.Enabled = true
+	}
+	if v := os.Getenv("NCMM_BARK_KEY"); v != "" {
+		cfg.Bark.Key = v
+		cfg.Bark.Enabled = true
+	}
+	if v := os.Getenv("NCMM_BARK_SERVER"); v != "" {
+		cfg.Bark.Server = v
+	}
+	if v := os.Getenv("NCMM_SCKEY"); v != "" {
+		cfg.ServerChan.SCKEY = v
+		cfg.ServerChan.Enabled = true
+	}
+	if v := os.Getenv("NCMM_TG_BOT_TOKEN"); v != "" {
+		cfg.Telegram.BotToken = v
+		cfg.Telegram.Enabled = true
+	}
+	if v := os.Getenv("NCMM_TG_USER_ID"); v != "" {
+		cfg.Telegram.UserID = v
+		cfg.Telegram.Enabled = true
+	}
+	if v := os.Getenv("NCMM_TG_API_HOST"); v != "" {
+		cfg.Telegram.APIHost = v
+	}
+	if v := os.Getenv("NCMM_TG_PROXY"); v != "" {
+		cfg.Telegram.Proxy = v
+	}
+	if v := os.Getenv("NCMM_DD_BOT_ACCESS_TOKEN"); v != "" {
+		cfg.DingTalk.AccessToken = v
+		cfg.DingTalk.Enabled = true
+	}
+	if v := os.Getenv("NCMM_DD_BOT_SECRET"); v != "" {
+		cfg.DingTalk.Secret = v
+	}
+	if v := os.Getenv("NCMM_QQ_SKEY"); v != "" {
+		cfg.CoolPush.SKey = v
+		cfg.CoolPush.Enabled = true
+	}
+	if v := os.Getenv("NCMM_QQ_MODE"); v != "" {
+		cfg.CoolPush.Mode = v
+	}
+	if v := os.Getenv("NCMM_PUSH_PLUS_TOKEN"); v != "" {
+		cfg.PushPlus.Token = v
+		cfg.PushPlus.Enabled = true
+	}
+	if v := os.Getenv("NCMM_QYWX_KEY"); v != "" {
+		cfg.WeComKey.Key = v
+		cfg.WeComKey.Enabled = true
+	}
+	if v := os.Getenv("NCMM_QYWX_AM"); v != "" {
+		// corpid,corpsecret,touser,agentid[,media_id]
+		parts := strings.Split(v, ",")
+		if len(parts) >= 4 {
+			cfg.WeComApp.CorpID = strings.TrimSpace(parts[0])
+			cfg.WeComApp.CorpSecret = strings.TrimSpace(parts[1])
+			cfg.WeComApp.ToUser = strings.TrimSpace(parts[2])
+			cfg.WeComApp.AgentID = strings.TrimSpace(parts[3])
+			if len(parts) >= 5 {
+				cfg.WeComApp.MediaID = strings.TrimSpace(parts[4])
+			}
+			cfg.WeComApp.Enabled = true
+		}
+	}
+}
+
+// ParseTimeout parses a duration string with default 10s.
+func ParseTimeout(s string) time.Duration {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 10 * time.Second
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return 10 * time.Second
+	}
+	return d
+}

--- a/pkg/notify/dispatcher.go
+++ b/pkg/notify/dispatcher.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 @3899. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
+
+package notify
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Message is a notification payload.
+type Message struct {
+	Title   string
+	Content string
+	Level   string // error / warn / info
+}
+
+// Channel sends a message to one provider.
+type Channel interface {
+	Name() string
+	Send(ctx context.Context, msg Message) error
+}
+
+// Dispatcher fans out to all enabled channels.
+type Dispatcher struct {
+	channels []Channel
+	client   *http.Client
+	timeout  time.Duration
+}
+
+// NewDispatcher builds a dispatcher from channel config.
+func NewDispatcher(cfg *ChannelsConfig, timeout time.Duration) *Dispatcher {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	client := &http.Client{Timeout: timeout}
+	d := &Dispatcher{
+		client:  client,
+		timeout: timeout,
+	}
+	if cfg == nil {
+		return d
+	}
+
+	if cfg.Webhook.Enabled && strings.TrimSpace(cfg.Webhook.URL) != "" {
+		d.channels = append(d.channels, &webhookChannel{cfg: cfg.Webhook, client: client})
+	}
+	if cfg.Bark.Enabled && strings.TrimSpace(cfg.Bark.Key) != "" {
+		d.channels = append(d.channels, &barkChannel{cfg: cfg.Bark, client: client})
+	}
+	if cfg.ServerChan.Enabled && strings.TrimSpace(cfg.ServerChan.SCKEY) != "" {
+		d.channels = append(d.channels, &serverChanChannel{cfg: cfg.ServerChan, client: client})
+	}
+	if cfg.Telegram.Enabled && strings.TrimSpace(cfg.Telegram.BotToken) != "" && strings.TrimSpace(cfg.Telegram.UserID) != "" {
+		d.channels = append(d.channels, &telegramChannel{cfg: cfg.Telegram, client: client, timeout: timeout})
+	}
+	if cfg.DingTalk.Enabled && strings.TrimSpace(cfg.DingTalk.AccessToken) != "" {
+		d.channels = append(d.channels, &dingTalkChannel{cfg: cfg.DingTalk, client: client})
+	}
+	if cfg.CoolPush.Enabled && strings.TrimSpace(cfg.CoolPush.SKey) != "" && strings.TrimSpace(cfg.CoolPush.Mode) != "" {
+		d.channels = append(d.channels, &coolPushChannel{cfg: cfg.CoolPush, client: client})
+	}
+	if cfg.PushPlus.Enabled && strings.TrimSpace(cfg.PushPlus.Token) != "" {
+		d.channels = append(d.channels, &pushPlusChannel{cfg: cfg.PushPlus, client: client})
+	}
+	if cfg.WeComKey.Enabled && strings.TrimSpace(cfg.WeComKey.Key) != "" {
+		d.channels = append(d.channels, &weComKeyChannel{cfg: cfg.WeComKey, client: client})
+	}
+	if cfg.WeComApp.Enabled && strings.TrimSpace(cfg.WeComApp.CorpID) != "" &&
+		strings.TrimSpace(cfg.WeComApp.CorpSecret) != "" && strings.TrimSpace(cfg.WeComApp.AgentID) != "" {
+		d.channels = append(d.channels, &weComAppChannel{cfg: cfg.WeComApp, client: client})
+	}
+	return d
+}
+
+// Len returns the number of enabled channels.
+func (d *Dispatcher) Len() int {
+	if d == nil {
+		return 0
+	}
+	return len(d.channels)
+}
+
+// SendAll sends to every channel; collects errors without aborting others.
+func (d *Dispatcher) SendAll(ctx context.Context, msg Message) error {
+	if d == nil || len(d.channels) == 0 {
+		return fmt.Errorf("no notify channels enabled")
+	}
+	if strings.TrimSpace(msg.Level) == "" {
+		msg.Level = "error"
+	}
+	var errs []string
+	for _, ch := range d.channels {
+		cctx, cancel := context.WithTimeout(ctx, d.timeout)
+		err := ch.Send(cctx, msg)
+		cancel()
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", ch.Name(), err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
+	return nil
+}

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 @3899. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
+
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReportNeedNotify(t *testing.T) {
+	r := NewReport("task")
+	if r.NeedNotify(true) {
+		t.Fatal("empty report should not notify")
+	}
+	r.AddSkip("a", "t", "no token")
+	if !r.NeedNotify(true) {
+		t.Fatal("skip with onSkip=true should notify")
+	}
+	if r.NeedNotify(false) {
+		t.Fatal("skip with onSkip=false should not notify")
+	}
+	r.AddFailureMsg("b", "sign", "not login")
+	if !r.NeedNotify(false) {
+		t.Fatal("failure should notify even if onSkip=false")
+	}
+}
+
+func TestReportSummary(t *testing.T) {
+	r := NewReport("task")
+	r.AddFailureMsg("./cookie.json", "sign", "Cookie 已失效")
+	r.AddSkip("./fan1.json", "daily-song-share", "token missing")
+	title, content := r.Summary("ncmm", true)
+	if !strings.Contains(title, "失败 1") || !strings.Contains(title, "跳过 1") {
+		t.Fatalf("unexpected title: %s", title)
+	}
+	if !strings.Contains(content, "【失败】") || !strings.Contains(content, "【跳过】") {
+		t.Fatalf("unexpected content: %s", content)
+	}
+	_, contentNoSkip := r.Summary("ncmm", false)
+	if strings.Contains(contentNoSkip, "【跳过】") {
+		t.Fatalf("skip section should be hidden: %s", contentNoSkip)
+	}
+}
+
+func TestWebhookChannel(t *testing.T) {
+	var gotBody map[string]string
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewDispatcher(&ChannelsConfig{
+		Webhook: WebhookConfig{
+			Enabled: true,
+			URL:     srv.URL,
+		},
+	}, 5*time.Second)
+	if d.Len() != 1 {
+		t.Fatalf("expected 1 channel, got %d", d.Len())
+	}
+	err := d.SendAll(context.Background(), Message{Title: "t1", Content: "c1", Level: "error"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method=%s", gotMethod)
+	}
+	if gotBody["title"] != "t1" || gotBody["content"] != "c1" {
+		t.Fatalf("body=%v", gotBody)
+	}
+}
+
+func TestWebhookBodyTemplate(t *testing.T) {
+	var raw string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		raw = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewDispatcher(&ChannelsConfig{
+		Webhook: WebhookConfig{
+			Enabled:      true,
+			URL:          srv.URL,
+			BodyTemplate: `{"msg_type":"text","content":{"text":"{{title}}\n{{content}}"}}`,
+		},
+	}, 5*time.Second)
+	if err := d.SendAll(context.Background(), Message{Title: "T", Content: "C"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(raw, `"text":"T\nC"`) && !strings.Contains(raw, "T") {
+		t.Fatalf("template body unexpected: %s", raw)
+	}
+}
+
+func TestLoadChannels(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notify.yaml")
+	content := `
+webhook:
+  enabled: true
+  url: "https://example.com/hook"
+telegram:
+  enabled: true
+  bot_token: "tok"
+  user_id: "1"
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, missing, err := LoadChannels(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if missing {
+		t.Fatal("expected file to exist")
+	}
+	if !cfg.Webhook.Enabled || cfg.Webhook.URL == "" {
+		t.Fatalf("webhook not loaded: %+v", cfg.Webhook)
+	}
+	if !cfg.Telegram.Enabled || cfg.Telegram.BotToken != "tok" {
+		t.Fatalf("telegram not loaded: %+v", cfg.Telegram)
+	}
+}

--- a/pkg/notify/report.go
+++ b/pkg/notify/report.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 @3899. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
+
+package notify
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Kind classifies a report item.
+type Kind string
+
+const (
+	KindFailure Kind = "failure"
+	KindSkip    Kind = "skip"
+)
+
+// Item is one failure or skip entry collected during a run.
+type Item struct {
+	Kind    Kind
+	Account string
+	Task    string
+	Message string
+}
+
+// Report collects failures/skips for end-of-run summary notification.
+type Report struct {
+	mu        sync.Mutex
+	Command   string
+	StartedAt time.Time
+	items     []Item
+}
+
+// NewReport creates an empty report.
+func NewReport(command string) *Report {
+	return &Report{
+		Command:   command,
+		StartedAt: time.Now(),
+	}
+}
+
+// SetCommand sets the command name shown in the summary.
+func (r *Report) SetCommand(command string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.Command = command
+}
+
+// AddFailure records a task/account failure.
+func (r *Report) AddFailure(account, task string, err error) {
+	if r == nil || err == nil {
+		return
+	}
+	r.add(KindFailure, account, task, err.Error())
+}
+
+// AddFailureMsg records a failure with a plain message.
+func (r *Report) AddFailureMsg(account, task, message string) {
+	if r == nil || strings.TrimSpace(message) == "" {
+		return
+	}
+	r.add(KindFailure, account, task, message)
+}
+
+// AddSkip records a skipped task.
+func (r *Report) AddSkip(account, task, reason string) {
+	if r == nil {
+		return
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = "skipped"
+	}
+	r.add(KindSkip, account, task, reason)
+}
+
+func (r *Report) add(kind Kind, account, task, message string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.items = append(r.items, Item{
+		Kind:    kind,
+		Account: strings.TrimSpace(account),
+		Task:    strings.TrimSpace(task),
+		Message: strings.TrimSpace(message),
+	})
+}
+
+// Items returns a copy of collected items.
+func (r *Report) Items() []Item {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]Item, len(r.items))
+	copy(out, r.items)
+	return out
+}
+
+// Counts returns failure and skip counts.
+func (r *Report) Counts() (failures, skips int) {
+	if r == nil {
+		return 0, 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, it := range r.items {
+		switch it.Kind {
+		case KindFailure:
+			failures++
+		case KindSkip:
+			skips++
+		}
+	}
+	return failures, skips
+}
+
+// NeedNotify reports whether a push should be sent.
+// Success never notifies. Failures always notify when present.
+// Skips notify only when onSkip is true.
+func (r *Report) NeedNotify(onSkip bool) bool {
+	failures, skips := r.Counts()
+	if failures > 0 {
+		return true
+	}
+	return onSkip && skips > 0
+}
+
+// Summary builds title and content for notification channels.
+func (r *Report) Summary(titlePrefix string, onSkip bool) (title, content string) {
+	if r == nil {
+		return "", ""
+	}
+	prefix := strings.TrimSpace(titlePrefix)
+	if prefix == "" {
+		prefix = "ncmm"
+	}
+
+	items := r.Items()
+	var failures, skips []Item
+	for _, it := range items {
+		switch it.Kind {
+		case KindFailure:
+			failures = append(failures, it)
+		case KindSkip:
+			if onSkip {
+				skips = append(skips, it)
+			}
+		}
+	}
+
+	parts := make([]string, 0, 2)
+	if len(failures) > 0 {
+		parts = append(parts, fmt.Sprintf("失败 %d", len(failures)))
+	}
+	if len(skips) > 0 {
+		parts = append(parts, fmt.Sprintf("跳过 %d", len(skips)))
+	}
+	title = fmt.Sprintf("[%s] 运行异常 (%s)", prefix, strings.Join(parts, " · "))
+
+	host, _ := os.Hostname()
+	r.mu.Lock()
+	cmd := r.Command
+	started := r.StartedAt
+	r.mu.Unlock()
+	if cmd == "" {
+		cmd = "ncmm"
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "主机: %s\n", host)
+	fmt.Fprintf(&b, "命令: %s\n", cmd)
+	fmt.Fprintf(&b, "开始: %s\n", started.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(&b, "结束: %s\n", time.Now().Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(&b, "失败: %d  跳过: %d\n", len(failures), len(skips))
+
+	idx := 1
+	if len(failures) > 0 {
+		b.WriteString("\n【失败】\n")
+		for _, it := range failures {
+			writeItem(&b, idx, it)
+			idx++
+		}
+	}
+	if len(skips) > 0 {
+		b.WriteString("\n【跳过】\n")
+		for _, it := range skips {
+			writeItem(&b, idx, it)
+			idx++
+		}
+	}
+	return title, b.String()
+}
+
+func writeItem(b *strings.Builder, idx int, it Item) {
+	account := it.Account
+	if account == "" {
+		account = "-"
+	}
+	task := it.Task
+	if task == "" {
+		task = "-"
+	}
+	fmt.Fprintf(b, "%d. [%s] %s\n   %s\n", idx, account, task, it.Message)
+}


### PR DESCRIPTION
1、增加多通道失败通知（策略在 config.yaml，通道示例 config/notify.yaml）。 
2、优化 ncmm task：
任一任务判定 Cookie/会话失效时标记该账号，后续任务全部跳过
（含 note、乐迷团、慢任务组），标记整次进程共享，其它账号不受影响。